### PR TITLE
Use FQNC with doc_fragments references

### DIFF
--- a/plugins/modules/bigip_apm_acl.py
+++ b/plugins/modules/bigip_apm_acl.py
@@ -163,7 +163,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_apm_network_access.py
+++ b/plugins/modules/bigip_apm_network_access.py
@@ -141,7 +141,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_apm_policy_fetch.py
+++ b/plugins/modules/bigip_apm_policy_fetch.py
@@ -55,7 +55,7 @@ notes:
   - Due to ID685681 it is not possible to execute ng_* tools via REST api on v12.x and 13.x, once this is fixed
     this restriction will be removed.
   - Requires BIG-IP >= 14.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_apm_policy_import.py
+++ b/plugins/modules/bigip_apm_policy_import.py
@@ -52,7 +52,7 @@ notes:
   - Due to ID685681 it is not possible to execute ng_* tools via REST api on v12.x and 13.x, once this is fixed
     this restriction will be removed.
   - Requires BIG-IP >= 14.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_appsvcs_extension.py
+++ b/plugins/modules/bigip_appsvcs_extension.py
@@ -62,7 +62,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_asm_dos_application.py
+++ b/plugins/modules/bigip_asm_dos_application.py
@@ -174,7 +174,7 @@ options:
     default: present
 notes:
   - Requires BIG-IP >= 13.1.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_asm_policy_fetch.py
+++ b/plugins/modules/bigip_asm_policy_fetch.py
@@ -65,7 +65,7 @@ options:
       - Device partition which contains ASM policy to export.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_asm_policy_import.py
+++ b/plugins/modules/bigip_asm_policy_import.py
@@ -124,7 +124,7 @@ options:
       - This parameter is also applied to indicate the partition of the C(parent) policy.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_asm_policy_manage.py
+++ b/plugins/modules/bigip_asm_policy_manage.py
@@ -94,7 +94,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_asm_policy_server_technology.py
+++ b/plugins/modules/bigip_asm_policy_server_technology.py
@@ -89,7 +89,7 @@ options:
 notes:
   - This module is primarily used as a component of configuring ASM policy in Ansible Galaxy ASM Policy Role.
   - Requires BIG-IP >= 13.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_asm_policy_signature_set.py
+++ b/plugins/modules/bigip_asm_policy_signature_set.py
@@ -121,7 +121,7 @@ options:
     default: Common
 notes:
   - This module is primarily used as a component of configuring ASM policy in Ansible Galaxy ASM Policy Role.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_cgnat_lsn_pool.py
+++ b/plugins/modules/bigip_cgnat_lsn_pool.py
@@ -184,7 +184,7 @@ options:
     default: present
 notes:
   - Requires CGNAT licensed and enabled on BIG-IP.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_cli_alias.py
+++ b/plugins/modules/bigip_cli_alias.py
@@ -57,7 +57,7 @@ options:
     choices:
       - present
       - absent
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_cli_script.py
+++ b/plugins/modules/bigip_cli_script.py
@@ -52,7 +52,7 @@ options:
     choices:
       - present
       - absent
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_command.py
+++ b/plugins/modules/bigip_command.py
@@ -105,7 +105,7 @@ options:
       - Change into this directory before running the command.
     type: str
     version_added: 2.6
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_config.py
+++ b/plugins/modules/bigip_config.py
@@ -60,7 +60,7 @@ options:
         by the module.
     type: bool
     default: no
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_configsync_action.py
+++ b/plugins/modules/bigip_configsync_action.py
@@ -50,7 +50,7 @@ options:
 notes:
   - Requires the objectpath Python package on the host. This is as easy as
     C(pip install objectpath).
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_data_group.py
+++ b/plugins/modules/bigip_data_group.py
@@ -152,7 +152,7 @@ options:
     default: present
 notes:
   - This module does NOT support atomic updates of data group members in a type C(internal) data group.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_auth.py
+++ b/plugins/modules/bigip_device_auth.py
@@ -143,7 +143,7 @@ options:
       - always
       - on_create
     default: always
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_device_auth_ldap.py
+++ b/plugins/modules/bigip_device_auth_ldap.py
@@ -142,7 +142,7 @@ options:
       - always
       - on_create
     default: always
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_certificate.py
+++ b/plugins/modules/bigip_device_certificate.py
@@ -113,7 +113,7 @@ options:
     choices:
         - cli
     default: cli
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_device_connectivity.py
+++ b/plugins/modules/bigip_device_connectivity.py
@@ -89,7 +89,7 @@ notes:
   - This module is primarily used as a component of configuring HA pairs of
     BIG-IP devices.
   - Requires BIG-IP >= 12.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_dns.py
+++ b/plugins/modules/bigip_device_dns.py
@@ -57,7 +57,7 @@ options:
       - absent
       - present
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_group.py
+++ b/plugins/modules/bigip_device_group.py
@@ -101,7 +101,7 @@ notes:
   - This module is primarily used as a component of configuring HA pairs of
     BIG-IP devices.
   - Requires BIG-IP >= 12.1.x.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_group_member.py
+++ b/plugins/modules/bigip_device_group_member.py
@@ -46,7 +46,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_ha_group.py
+++ b/plugins/modules/bigip_device_ha_group.py
@@ -122,7 +122,7 @@ options:
     default: present
 notes:
   - This module does not support atomic removal of HA group objects.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_device_httpd.py
+++ b/plugins/modules/bigip_device_httpd.py
@@ -110,7 +110,7 @@ notes:
     C(pip install requests).
 requirements:
   - requests
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Joe Reifel (@JoeReifel)
   - Tim Rupp (@caphrim007)

--- a/plugins/modules/bigip_device_info.py
+++ b/plugins/modules/bigip_device_info.py
@@ -162,7 +162,7 @@ options:
       - "!virtual-servers"
       - "!vlans"
     aliases: ['include']
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_license.py
+++ b/plugins/modules/bigip_device_license.py
@@ -60,7 +60,7 @@ options:
         ignored if it is provided.
     type: bool
     default: no
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_device_ntp.py
+++ b/plugins/modules/bigip_device_ntp.py
@@ -40,7 +40,7 @@ options:
       - The timezone to set for NTP lookups. At least one of C(ntp_servers) or
         C(timezone) is required.
     type: str
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_sshd.py
+++ b/plugins/modules/bigip_device_sshd.py
@@ -75,7 +75,7 @@ options:
     type: int
 notes:
   - Requires BIG-IP version 12.0.0 or greater
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_syslog.py
+++ b/plugins/modules/bigip_device_syslog.py
@@ -258,7 +258,7 @@ options:
       - info
       - notice
       - warning
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_device_traffic_group.py
+++ b/plugins/modules/bigip_device_traffic_group.py
@@ -96,7 +96,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_device_trust.py
+++ b/plugins/modules/bigip_device_trust.py
@@ -76,7 +76,7 @@ options:
       - absent
       - present
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_dns_cache_resolver.py
+++ b/plugins/modules/bigip_dns_cache_resolver.py
@@ -79,7 +79,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_dns_nameserver.py
+++ b/plugins/modules/bigip_dns_nameserver.py
@@ -73,7 +73,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_dns_resolver.py
+++ b/plugins/modules/bigip_dns_resolver.py
@@ -93,7 +93,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_dns_zone.py
+++ b/plugins/modules/bigip_dns_zone.py
@@ -98,7 +98,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Greg Crosby (@crosbygw)

--- a/plugins/modules/bigip_file_copy.py
+++ b/plugins/modules/bigip_file_copy.py
@@ -73,7 +73,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_firewall_address_list.py
+++ b/plugins/modules/bigip_firewall_address_list.py
@@ -96,7 +96,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_firewall_dos_profile.py
+++ b/plugins/modules/bigip_firewall_dos_profile.py
@@ -64,7 +64,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_firewall_dos_vector.py
+++ b/plugins/modules/bigip_firewall_dos_vector.py
@@ -278,7 +278,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 requirements:
   - BIG-IP >= v13.0.0
 author:

--- a/plugins/modules/bigip_firewall_global_rules.py
+++ b/plugins/modules/bigip_firewall_global_rules.py
@@ -52,7 +52,7 @@ options:
     description:
       - Description for the global list of firewall rules.
     type: str
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_firewall_log_profile.py
+++ b/plugins/modules/bigip_firewall_log_profile.py
@@ -125,7 +125,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_firewall_log_profile_network.py
+++ b/plugins/modules/bigip_firewall_log_profile_network.py
@@ -223,7 +223,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_firewall_policy.py
+++ b/plugins/modules/bigip_firewall_policy.py
@@ -57,7 +57,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_firewall_port_list.py
+++ b/plugins/modules/bigip_firewall_port_list.py
@@ -62,7 +62,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_firewall_rule.py
+++ b/plugins/modules/bigip_firewall_rule.py
@@ -251,7 +251,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_firewall_rule_list.py
+++ b/plugins/modules/bigip_firewall_rule_list.py
@@ -57,7 +57,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_firewall_schedule.py
+++ b/plugins/modules/bigip_firewall_schedule.py
@@ -88,7 +88,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_gtm_datacenter.py
+++ b/plugins/modules/bigip_gtm_datacenter.py
@@ -61,7 +61,7 @@ options:
     type: str
     default: Common
     version_added: 2.5
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_global.py
+++ b/plugins/modules/bigip_gtm_global.py
@@ -39,7 +39,7 @@ options:
       - Specifies that the system synchronizes Domain Name System (DNS) zone files among the
         synchronization group members.
     type: bool
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_monitor_bigip.py
+++ b/plugins/modules/bigip_gtm_monitor_bigip.py
@@ -120,7 +120,7 @@ options:
     default: present
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_monitor_external.py
+++ b/plugins/modules/bigip_gtm_monitor_external.py
@@ -92,7 +92,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_monitor_firepass.py
+++ b/plugins/modules/bigip_gtm_monitor_firepass.py
@@ -143,7 +143,7 @@ options:
         marks the Secure Access Manager system down.
       - When creating a new monitor, if this parameter is not specified, the default is C(95).
     type: int
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_monitor_http.py
+++ b/plugins/modules/bigip_gtm_monitor_http.py
@@ -144,7 +144,7 @@ options:
       - always
       - on_create
     default: always
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_monitor_https.py
+++ b/plugins/modules/bigip_gtm_monitor_https.py
@@ -166,7 +166,7 @@ options:
     description:
       - Specifies a key for a client certificate that the monitor sends to the target SSL server.
     type: str
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_monitor_tcp.py
+++ b/plugins/modules/bigip_gtm_monitor_tcp.py
@@ -125,7 +125,7 @@ options:
       - A match for this string means that the web server was down.
       - To use this option, you must specify values for C(send) and C(receive).
     type: bool
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_monitor_tcp_half_open.py
+++ b/plugins/modules/bigip_gtm_monitor_tcp_half_open.py
@@ -122,7 +122,7 @@ options:
     default: present
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_pool.py
+++ b/plugins/modules/bigip_gtm_pool.py
@@ -212,7 +212,7 @@ options:
     version_added: 2.8
 notes:
   - Support for TMOS versions below v12.x has been deprecated for this module, and will be removed in Ansible 2.12.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_pool_member.py
+++ b/plugins/modules/bigip_gtm_pool_member.py
@@ -177,7 +177,7 @@ options:
       - enabled
       - disabled
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_server.py
+++ b/plugins/modules/bigip_gtm_server.py
@@ -294,7 +294,7 @@ options:
         type: int
     type: dict
     version_added: 2.8
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Robert Teller (@r-teller)
   - Tim Rupp (@caphrim007)

--- a/plugins/modules/bigip_gtm_topology_record.py
+++ b/plugins/modules/bigip_gtm_topology_record.py
@@ -171,7 +171,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_gtm_topology_region.py
+++ b/plugins/modules/bigip_gtm_topology_region.py
@@ -112,7 +112,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_gtm_virtual_server.py
+++ b/plugins/modules/bigip_gtm_virtual_server.py
@@ -197,7 +197,7 @@ options:
       - enabled
       - disabled
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_gtm_wide_ip.py
+++ b/plugins/modules/bigip_gtm_wide_ip.py
@@ -121,7 +121,7 @@ options:
     version_added: 2.8
 notes:
   - Support for TMOS versions below v12.x has been deprecated for this module, and will be removed in Ansible 2.12.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_hostname.py
+++ b/plugins/modules/bigip_hostname.py
@@ -25,7 +25,7 @@ options:
       - Hostname of the BIG-IP host.
     type: str
     required: True
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Matthew Lam (@mryanlam)

--- a/plugins/modules/bigip_iapp_service.py
+++ b/plugins/modules/bigip_iapp_service.py
@@ -116,7 +116,7 @@ options:
         the C(parameters) field.
     type: str
     version_added: 2.7
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_iapp_template.py
+++ b/plugins/modules/bigip_iapp_template.py
@@ -67,7 +67,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_ike_peer.py
+++ b/plugins/modules/bigip_ike_peer.py
@@ -192,7 +192,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_imish_config.py
+++ b/plugins/modules/bigip_imish_config.py
@@ -206,7 +206,7 @@ notes:
   - Abbreviated commands are NOT idempotent, see
     L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-
     abbreviated-commands).
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_ipsec_policy.py
+++ b/plugins/modules/bigip_ipsec_policy.py
@@ -159,7 +159,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_irule.py
+++ b/plugins/modules/bigip_irule.py
@@ -60,7 +60,7 @@ options:
     type: str
     default: Common
     version_added: 2.5
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_log_destination.py
+++ b/plugins/modules/bigip_log_destination.py
@@ -248,7 +248,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_log_publisher.py
+++ b/plugins/modules/bigip_log_publisher.py
@@ -47,7 +47,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_lx_package.py
+++ b/plugins/modules/bigip_lx_package.py
@@ -49,7 +49,7 @@ notes:
 requirements:
   - Requires BIG-IP >= 12.1.0
   - The 'rpm' tool installed on the Ansible controller
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_management_route.py
+++ b/plugins/modules/bigip_management_route.py
@@ -57,7 +57,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_message_routing_peer.py
+++ b/plugins/modules/bigip_message_routing_peer.py
@@ -97,7 +97,7 @@ options:
     default: present
 notes:
   - Requires BIG-IP >= 14.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_message_routing_protocol.py
+++ b/plugins/modules/bigip_message_routing_protocol.py
@@ -79,7 +79,7 @@ options:
     default: present
 notes:
   - Requires BIG-IP >= 14.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_message_routing_route.py
+++ b/plugins/modules/bigip_message_routing_route.py
@@ -77,7 +77,7 @@ options:
     default: present
 notes:
   - Requires BIG-IP >= 14.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_message_routing_router.py
+++ b/plugins/modules/bigip_message_routing_router.py
@@ -116,7 +116,7 @@ options:
     default: present
 notes:
   - Requires BIG-IP >= 14.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_message_routing_transport_config.py
+++ b/plugins/modules/bigip_message_routing_transport_config.py
@@ -90,7 +90,7 @@ options:
     default: present
 notes:
   - Requires BIG-IP >= 14.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_monitor_dns.py
+++ b/plugins/modules/bigip_monitor_dns.py
@@ -228,7 +228,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_monitor_external.py
+++ b/plugins/modules/bigip_monitor_external.py
@@ -99,7 +99,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_monitor_gateway_icmp.py
+++ b/plugins/modules/bigip_monitor_gateway_icmp.py
@@ -165,7 +165,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_monitor_http.py
+++ b/plugins/modules/bigip_monitor_http.py
@@ -127,7 +127,7 @@ options:
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_monitor_https.py
+++ b/plugins/modules/bigip_monitor_https.py
@@ -133,7 +133,7 @@ options:
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_monitor_ldap.py
+++ b/plugins/modules/bigip_monitor_ldap.py
@@ -159,7 +159,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Greg Crosby (@crosbygw)

--- a/plugins/modules/bigip_monitor_snmp_dca.py
+++ b/plugins/modules/bigip_monitor_snmp_dca.py
@@ -143,7 +143,7 @@ notes:
     is broken in the REST API and does not function correctly in C(tmsh); for
     example you cannot remove user-defined params. Therefore, there is no way
     to automatically configure it.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_monitor_tcp.py
+++ b/plugins/modules/bigip_monitor_tcp.py
@@ -103,7 +103,7 @@ options:
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_monitor_tcp_echo.py
+++ b/plugins/modules/bigip_monitor_tcp_echo.py
@@ -85,7 +85,7 @@ options:
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_monitor_tcp_half_open.py
+++ b/plugins/modules/bigip_monitor_tcp_half_open.py
@@ -95,7 +95,7 @@ options:
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_monitor_udp.py
+++ b/plugins/modules/bigip_monitor_udp.py
@@ -108,7 +108,7 @@ options:
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_node.py
+++ b/plugins/modules/bigip_node.py
@@ -205,7 +205,7 @@ options:
     type: str
     default: Common
     version_added: 2.5
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_partition.py
+++ b/plugins/modules/bigip_partition.py
@@ -45,7 +45,7 @@ options:
     default: present
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_password_policy.py
+++ b/plugins/modules/bigip_password_policy.py
@@ -75,7 +75,7 @@ options:
         remember a password on a specific computer and how many passwords
         to remember.
     type: int
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_policy.py
+++ b/plugins/modules/bigip_policy.py
@@ -79,7 +79,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_policy_rule.py
+++ b/plugins/modules/bigip_policy_rule.py
@@ -136,7 +136,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 requirements:
   - BIG-IP >= v12.1.0
 author:

--- a/plugins/modules/bigip_pool.py
+++ b/plugins/modules/bigip_pool.py
@@ -185,7 +185,7 @@ notes:
   - To add members to a pool, use the C(bigip_pool_member) module. Previously, the
     C(bigip_pool) module allowed the management of members, but this has been removed
     in version 2.5 of Ansible.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_pool_member.py
+++ b/plugins/modules/bigip_pool_member.py
@@ -210,7 +210,7 @@ options:
 notes:
   - In previous versions of this module, which used the SDK, the C(name) parameter would act as C(fqdn) if C(address) or
     C(fqdn) were not provided.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_profile_analytics.py
+++ b/plugins/modules/bigip_profile_analytics.py
@@ -109,7 +109,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_profile_client_ssl.py
+++ b/plugins/modules/bigip_profile_client_ssl.py
@@ -239,7 +239,7 @@ options:
     version_added: 2.5
 notes:
   - Requires BIG-IP software version >= 12
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_profile_dns.py
+++ b/plugins/modules/bigip_profile_dns.py
@@ -150,7 +150,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_profile_fastl4.py
+++ b/plugins/modules/bigip_profile_fastl4.py
@@ -294,7 +294,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_profile_http.py
+++ b/plugins/modules/bigip_profile_http.py
@@ -374,7 +374,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_profile_http2.py
+++ b/plugins/modules/bigip_profile_http2.py
@@ -110,7 +110,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_profile_http_compression.py
+++ b/plugins/modules/bigip_profile_http_compression.py
@@ -102,7 +102,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_profile_oneconnect.py
+++ b/plugins/modules/bigip_profile_oneconnect.py
@@ -127,7 +127,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_profile_persistence_cookie.py
+++ b/plugins/modules/bigip_profile_persistence_cookie.py
@@ -168,7 +168,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_profile_persistence_src_addr.py
+++ b/plugins/modules/bigip_profile_persistence_src_addr.py
@@ -94,7 +94,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_profile_server_ssl.py
+++ b/plugins/modules/bigip_profile_server_ssl.py
@@ -126,7 +126,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_profile_tcp.py
+++ b/plugins/modules/bigip_profile_tcp.py
@@ -122,7 +122,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_profile_udp.py
+++ b/plugins/modules/bigip_profile_udp.py
@@ -67,7 +67,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_provision.py
+++ b/plugins/modules/bigip_provision.py
@@ -91,7 +91,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Greg Crosby (@crosbygw)

--- a/plugins/modules/bigip_qkview.py
+++ b/plugins/modules/bigip_qkview.py
@@ -77,7 +77,7 @@ notes:
     should be aware of how these Ansible products execute jobs in restricted
     environments. More informat can be found here
     https://clouddocs.f5.com/products/orchestration/ansible/devel/usage/module-usage-with-tower.html
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_remote_role.py
+++ b/plugins/modules/bigip_remote_role.py
@@ -93,7 +93,7 @@ options:
       - absent
       - present
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_remote_syslog.py
+++ b/plugins/modules/bigip_remote_syslog.py
@@ -58,7 +58,7 @@ options:
       - absent
       - present
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_remote_user.py
+++ b/plugins/modules/bigip_remote_user.py
@@ -56,7 +56,7 @@ options:
     description:
       - User defined description.
     type: str
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_routedomain.py
+++ b/plugins/modules/bigip_routedomain.py
@@ -104,7 +104,7 @@ options:
       - Specifies AFM policy to be attached to route domain.
     type: str
     version_added: 2.8
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_selfip.py
+++ b/plugins/modules/bigip_selfip.py
@@ -88,7 +88,7 @@ options:
     type: str
     default: Common
     version_added: 2.5
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_service_policy.py
+++ b/plugins/modules/bigip_service_policy.py
@@ -53,7 +53,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_smtp.py
+++ b/plugins/modules/bigip_smtp.py
@@ -101,7 +101,7 @@ options:
       - always
       - on_create
     default: always
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_snat_pool.py
+++ b/plugins/modules/bigip_snat_pool.py
@@ -57,7 +57,7 @@ notes:
   - When C(bigip_snat_pool) object is removed it also removes any associated C(bigip_snat_translation) objects.
   - This is a BIG-IP behavior not module behavior and it only occurs when the C(bigip_snat_translation) objects
     are also not referenced by another C(bigip_snat_pool).
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_snat_translation.py
+++ b/plugins/modules/bigip_snat_translation.py
@@ -95,7 +95,7 @@ options:
       - The accepted value range is C(0 - 4294967295) seconds, specifying C(indefinite) will
         set it to the maximum value.
     type: str
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Greg Crosby (@crosbygw)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_snmp.py
+++ b/plugins/modules/bigip_snmp.py
@@ -67,7 +67,7 @@ options:
     description:
       - Specifies the description of this system's physical location.
     type: str
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_snmp_community.py
+++ b/plugins/modules/bigip_snmp_community.py
@@ -165,7 +165,7 @@ options:
       - Device partition to manage resources on.
     type: str
     default: Common
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_snmp_trap.py
+++ b/plugins/modules/bigip_snmp_trap.py
@@ -80,7 +80,7 @@ notes:
   - The C(network) option is not supported on versions of BIG-IP < 12.1.0 because
     the platform did not support that option until 12.1.0. If used on versions
     < 12.1.0, it will simply be ignored.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_software_image.py
+++ b/plugins/modules/bigip_software_image.py
@@ -46,7 +46,7 @@ options:
       - This may be an absolute or relative location on the Ansible controller.
       - Image names, whether they are base ISOs or hotfix ISOs, B(must) be unique.
     type: str
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_software_install.py
+++ b/plugins/modules/bigip_software_install.py
@@ -40,7 +40,7 @@ options:
       - activated
       - installed
     default: activated
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_software_update.py
+++ b/plugins/modules/bigip_software_update.py
@@ -38,7 +38,7 @@ options:
       - daily
       - monthly
       - weekly
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_ssl_certificate.py
+++ b/plugins/modules/bigip_ssl_certificate.py
@@ -62,7 +62,7 @@ notes:
     files or templates directory. To have it behave that way, use the Ansible
     file or template lookup (see Examples). The lookups behave as expected in
     a role context.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 requirements:
   - BIG-IP >= v12
 author:

--- a/plugins/modules/bigip_ssl_key.py
+++ b/plugins/modules/bigip_ssl_key.py
@@ -60,7 +60,7 @@ notes:
     files or templates directory. To have it behave that way, use the Ansible
     file or template lookup (see Examples). The lookups behave as expected in
     a role context.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 requirements:
   - BIG-IP >= v12
 author:

--- a/plugins/modules/bigip_ssl_ocsp.py
+++ b/plugins/modules/bigip_ssl_ocsp.py
@@ -136,7 +136,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 notes:
   - Requires BIG-IP >= 13.x.
 author:

--- a/plugins/modules/bigip_static_route.py
+++ b/plugins/modules/bigip_static_route.py
@@ -91,7 +91,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_sys_daemon_log_tmm.py
+++ b/plugins/modules/bigip_sys_daemon_log_tmm.py
@@ -140,7 +140,7 @@ options:
     choices:
       - present
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Wojciech Wypior (@wojtek0806)
 '''

--- a/plugins/modules/bigip_sys_db.py
+++ b/plugins/modules/bigip_sys_db.py
@@ -43,7 +43,7 @@ options:
     type: str
 notes:
   - Requires BIG-IP version 12.0.0 or greater
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_sys_global.py
+++ b/plugins/modules/bigip_sys_global.py
@@ -71,7 +71,7 @@ options:
     choices:
       - present
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_timer_policy.py
+++ b/plugins/modules/bigip_timer_policy.py
@@ -101,7 +101,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_traffic_selector.py
+++ b/plugins/modules/bigip_traffic_selector.py
@@ -67,7 +67,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_trunk.py
+++ b/plugins/modules/bigip_trunk.py
@@ -123,7 +123,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_tunnel.py
+++ b/plugins/modules/bigip_tunnel.py
@@ -149,7 +149,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigip_ucs.py
+++ b/plugins/modules/bigip_ucs.py
@@ -98,7 +98,7 @@ notes:
    - This module does not support re-licensing a BIG-IP restored from a UCS
    - This module does not support restoring encrypted archives on replacement
      RMA units.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_ucs_fetch.py
+++ b/plugins/modules/bigip_ucs_fetch.py
@@ -69,7 +69,7 @@ notes:
     should be aware of how these Ansible products execute jobs in restricted
     environments. More information can be found here
     https://clouddocs.f5.com/products/orchestration/ansible/devel/usage/module-usage-with-tower.html
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_user.py
+++ b/plugins/modules/bigip_user.py
@@ -88,7 +88,7 @@ options:
     version_added: 2.5
 notes:
    - Requires BIG-IP versions >= 12.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_vcmp_guest.py
+++ b/plugins/modules/bigip_vcmp_guest.py
@@ -172,7 +172,7 @@ notes:
     means that it is not unusual for a vCMP host with many guests to take a
     long time (60+ minutes) to reboot and bring all the guests online. The
     BIG-IP chassis will be available before all vCMP guests are online.
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_virtual_address.py
+++ b/plugins/modules/bigip_virtual_address.py
@@ -194,7 +194,7 @@ options:
         valus is C(no).
     version_added: 2.7
     type: bool
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_virtual_server.py
+++ b/plugins/modules/bigip_virtual_server.py
@@ -495,7 +495,7 @@ options:
          - serverside
     type: list
     version_added: 2.8
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_vlan.py
+++ b/plugins/modules/bigip_vlan.py
@@ -186,7 +186,7 @@ options:
     version_added: 2.8
 notes:
   - Requires BIG-IP versions >= 12.0.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
   - Wojciech Wypior (@wojtek0806)

--- a/plugins/modules/bigip_wait.py
+++ b/plugins/modules/bigip_wait.py
@@ -45,7 +45,7 @@ options:
     description:
       - This overrides the normal error message from a failure to meet the required conditions.
     type: str
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigiq_application_fasthttp.py
+++ b/plugins/modules/bigiq_application_fasthttp.py
@@ -107,7 +107,7 @@ options:
       - If the module should wait for the application to be created, deleted or updated.
     type: bool
     default: yes
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 notes:
   - This module does not support updating of your application (whether deployed or not).
     If you need to update the application, the recommended practice is to remove and

--- a/plugins/modules/bigiq_application_fastl4_tcp.py
+++ b/plugins/modules/bigiq_application_fastl4_tcp.py
@@ -107,7 +107,7 @@ options:
       - If the module should wait for the application to be created, deleted or updated.
     type: bool
     default: yes
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 notes:
   - This module does not support updating of your application (whether deployed or not).
     If you need to update the application, the recommended practice is to remove and

--- a/plugins/modules/bigiq_application_fastl4_udp.py
+++ b/plugins/modules/bigiq_application_fastl4_udp.py
@@ -107,7 +107,7 @@ options:
       - If the module should wait for the application to be created, deleted or updated.
     type: bool
     default: yes
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 notes:
   - This module does not support updating of your application (whether deployed or not).
     If you need to update the application, the recommended practice is to remove and

--- a/plugins/modules/bigiq_application_http.py
+++ b/plugins/modules/bigiq_application_http.py
@@ -107,7 +107,7 @@ options:
       - If the module should wait for the application to be created, deleted or updated.
     type: bool
     default: yes
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 notes:
   - This module does not support updating of your application (whether deployed or not).
     If you need to update the application, the recommended practice is to remove and

--- a/plugins/modules/bigiq_application_https_offload.py
+++ b/plugins/modules/bigiq_application_https_offload.py
@@ -175,7 +175,7 @@ options:
       - If the module should wait for the application to be created, deleted or updated.
     type: bool
     default: yes
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 notes:
   - This module will not work on BIGIQ version 6.1.x or greater.
 author:

--- a/plugins/modules/bigiq_application_https_waf.py
+++ b/plugins/modules/bigiq_application_https_waf.py
@@ -182,7 +182,7 @@ options:
       - If the module should wait for the application to be created, deleted or updated.
     type: bool
     default: yes
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 notes:
   - This module will not work on BIGIQ version 6.1.x or greater.
 author:

--- a/plugins/modules/bigiq_device_discovery.py
+++ b/plugins/modules/bigiq_device_discovery.py
@@ -160,7 +160,7 @@ options:
       - absent
       - present
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 notes:
   - BIG-IQ >= 6.1.0.
   - This module does not support atomic removal of discovered modules on the device.

--- a/plugins/modules/bigiq_device_info.py
+++ b/plugins/modules/bigiq_device_info.py
@@ -44,7 +44,7 @@ options:
       - "!regkey-pools"
       - "!system-info"
       - "!vlans"
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigiq_regkey_license.py
+++ b/plugins/modules/bigiq_regkey_license.py
@@ -56,7 +56,7 @@ options:
     default: present
 requirements:
   - BIG-IQ >= 5.3.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigiq_regkey_license_assignment.py
+++ b/plugins/modules/bigiq_regkey_license_assignment.py
@@ -76,7 +76,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigiq_regkey_pool.py
+++ b/plugins/modules/bigiq_regkey_pool.py
@@ -48,7 +48,7 @@ options:
     default: present
 requirements:
   - BIG-IQ >= 5.3.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigiq_utility_license.py
+++ b/plugins/modules/bigiq_utility_license.py
@@ -46,7 +46,7 @@ options:
     default: present
 requirements:
   - BIG-IQ >= 5.3.0
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''

--- a/plugins/modules/bigiq_utility_license_assignment.py
+++ b/plugins/modules/bigiq_utility_license_assignment.py
@@ -88,7 +88,7 @@ options:
       - present
       - absent
     default: present
-extends_documentation_fragment: f5
+extends_documentation_fragment: f5networks.f5_modules.f5
 author:
   - Tim Rupp (@caphrim007)
 '''


### PR DESCRIPTION
Test with:

```bash
ansible-galaxy collection build --output-path alan
ansible-galaxy collection install alan/f5networks-f5_modules-1.0.0-rc1.tar.gz -p alan2
ANSIBLE_COLLECTIONS_PATHS=alan2/ ansible-doc -M alan2/ansible_collections/f5networks/f5_modules/plugins/modules/ -t module bigip_device_group_member
```

Tested against https://github.com/bcoca/ansible-minmal

Maybe https://github.com/F5Networks/f5-ansible/issues/1506 related, maybe not, I don't have a firm grasp on the repo structure.

output:

https://gist.github.com/AlanCoding/e070531520a86fab24708b62607a7212